### PR TITLE
 feat: remove download restrictions, add stats banner, expand hero, team search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2775,6 +2775,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import { Forms } from "@/components/sections/Forms";
 import { Passers } from "@/components/sections/Passers";
 import { Contact } from "@/components/sections/Contact";
 import { ScrollToTop } from "@/components/ui/ScrollToTop";
+import { Stats } from "@/components/sections/Stats";
 
 export default function Home() {
   return (
@@ -16,6 +17,7 @@ export default function Home() {
       <Navbar />
       <main id="main-content">
         <Hero />
+        <Stats />
         <VideoIntro />
         <About />
         <Team />

--- a/src/components/sections/Forms.tsx
+++ b/src/components/sections/Forms.tsx
@@ -10,7 +10,6 @@ import {
   BarChart3,
   BookOpen,
   Download,
-  Lock,
 } from "lucide-react";
 import {
   fadeInUp,
@@ -18,8 +17,7 @@ import {
   staggerItem,
   cardHover,
 } from "@/utils/animations";
-import { useAuth } from "@/contexts/AuthContext";
-import { cn } from "@/utils/helpers";
+
 
 // Forms data
 const FORMS = [
@@ -93,34 +91,7 @@ const colorMap: Record<string, { bg: string; text: string; border: string }> = {
   indigo: { bg: "bg-indigo-100", text: "text-indigo-600", border: "hover:border-indigo-400" },
 };
 
-// Protected Download Button Component
-function ProtectedDownloadButton({ 
-  href, 
-  children, 
-  className = "" 
-}: { 
-  href: string; 
-  children: React.ReactNode; 
-  className?: string;
-}) {
-  const { requireLogin, auth } = useAuth();
 
-  const handleClick = (e: React.MouseEvent) => {
-    e.preventDefault();
-    requireLogin(href);
-  };
-
-  return (
-    <motion.button
-      onClick={handleClick}
-      whileHover={{ x: 5 }}
-      className={cn("inline-flex items-center gap-2", className)}
-    >
-      {!auth.isLoggedIn && <Lock className="w-3 h-3" />}
-      {children}
-    </motion.button>
-  );
-}
 
 export function Forms() {
   const sectionRef = useRef<HTMLDivElement>(null);
@@ -188,13 +159,16 @@ export function Forms() {
                   </p>
 
                   {/* Download Link */}
-                  <ProtectedDownloadButton
+                  <motion.a
                     href={form.downloadLink}
-                    className={`font-semibold ${colors.text} hover:underline`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    whileHover={{ x: 5 }}
+                    className={`inline-flex items-center gap-2 font-semibold ${colors.text} hover:underline`}
                   >
                     Download
                     <Download className="w-4 h-4" />
-                  </ProtectedDownloadButton>
+                  </motion.a>
                 </motion.div>
               </motion.div>
             );

--- a/src/components/sections/Stats.tsx
+++ b/src/components/sections/Stats.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useRef, useEffect, useState } from "react";
+import { motion, useInView } from "framer-motion";
+import { Users, MapPin, GraduationCap, BookOpen } from "lucide-react";
+import { staggerContainer, staggerItem } from "@/utils/animations";
+
+const STATS = [
+  {
+    icon: MapPin,
+    value: 4,
+    suffix: "",
+    label: "Municipalities Covered",
+    sub: "Manolo Fortich, Libona, Baungon & Malitbog",
+    color: "text-blue-600",
+    bg: "bg-blue-50",
+  },
+  {
+    icon: Users,
+    value: 22,
+    suffix: "+",
+    label: "Dedicated Educators",
+    sub: "Teachers & program coordinators",
+    color: "text-green-600",
+    bg: "bg-green-50",
+  },
+  {
+    icon: BookOpen,
+    value: 2,
+    suffix: "",
+    label: "ALS Programs",
+    sub: "Elementary & Secondary level",
+    color: "text-purple-600",
+    bg: "bg-purple-50",
+  },
+  {
+    icon: GraduationCap,
+    value: 100,
+    suffix: "%",
+    label: "Commitment to Learners",
+    sub: "Free, flexible, quality education",
+    color: "text-accent-600",
+    bg: "bg-accent-50",
+  },
+];
+
+function AnimatedCounter({ target, suffix }: { target: number; suffix: string }) {
+  const [count, setCount] = useState(0);
+  const ref = useRef<HTMLSpanElement>(null);
+  const isInView = useInView(ref, { once: true });
+
+  useEffect(() => {
+    if (!isInView) return;
+    let start = 0;
+    const duration = 1500;
+    const step = Math.ceil(target / (duration / 16));
+
+    const timer = setInterval(() => {
+      start += step;
+      if (start >= target) {
+        setCount(target);
+        clearInterval(timer);
+      } else {
+        setCount(start);
+      }
+    }, 16);
+
+    return () => clearInterval(timer);
+  }, [isInView, target]);
+
+  return (
+    <span ref={ref} className="tabular-nums">
+      {count}
+      {suffix}
+    </span>
+  );
+}
+
+export function Stats() {
+  const sectionRef = useRef<HTMLDivElement>(null);
+  const isInView = useInView(sectionRef, { once: true, amount: 0.3 });
+
+  return (
+    <section ref={sectionRef} className="bg-white border-y border-gray-100 py-12">
+      <div className="container-custom">
+        <motion.div
+          variants={staggerContainer}
+          initial="hidden"
+          animate={isInView ? "visible" : "hidden"}
+          className="grid grid-cols-2 lg:grid-cols-4 gap-6"
+        >
+          {STATS.map((stat) => {
+            const Icon = stat.icon;
+            return (
+              <motion.div
+                key={stat.label}
+                variants={staggerItem}
+                className="flex flex-col items-center text-center p-6 rounded-2xl hover:shadow-md transition-shadow duration-300"
+              >
+                <div className={`p-4 rounded-2xl ${stat.bg} mb-4`}>
+                  <Icon className={`w-7 h-7 ${stat.color}`} />
+                </div>
+                <p className={`text-4xl font-bold font-heading ${stat.color} mb-1`}>
+                  <AnimatedCounter target={stat.value} suffix={stat.suffix} />
+                </p>
+                <p className="text-primary-800 font-semibold text-sm mb-1">
+                  {stat.label}
+                </p>
+                <p className="text-gray-500 text-xs leading-snug">{stat.sub}</p>
+              </motion.div>
+            );
+          })}
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/Team.tsx
+++ b/src/components/sections/Team.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect } from "react";
 import { motion, useInView, AnimatePresence } from "framer-motion";
 import Image from "next/image";
-import { Mail, User, X, MapPin, Briefcase, Award, ChevronDown, ChevronUp, Users } from "lucide-react";
+import { Mail, User, X, MapPin, Briefcase, Award, ChevronDown, ChevronUp, Users, Search } from "lucide-react";
 import { TEAM_MEMBERS, MUNICIPALITIES } from "@/constants";
 import { cn } from "@/utils/helpers";
 import {
@@ -185,6 +185,7 @@ function TeamMemberModal({
 
 export function Team() {
   const [activeTab, setActiveTab] = useState<string>("All");
+  const [searchQuery, setSearchQuery] = useState("");
   const [selectedMember, setSelectedMember] = useState<TeamMember | null>(null);
   const [isExpanded, setIsExpanded] = useState(false);
   const sectionRef = useRef<HTMLDivElement>(null);
@@ -193,11 +194,14 @@ export function Team() {
   // Number of members to show when collapsed
   const INITIAL_DISPLAY_COUNT = 8;
 
-  // Filter team members by municipality
-  const filteredMembers =
-    activeTab === "All"
-      ? TEAM_MEMBERS
-      : TEAM_MEMBERS.filter((member) => member.district === activeTab);
+  // Filter team members by municipality and search query
+  const filteredMembers = TEAM_MEMBERS.filter((member) => {
+    const matchesTab = activeTab === "All" || member.district === activeTab;
+    const matchesSearch = searchQuery === "" ||
+      member.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      member.role.toLowerCase().includes(searchQuery.toLowerCase());
+    return matchesTab && matchesSearch;
+  });
 
   // Members to display based on expanded state
   const displayedMembers = isExpanded 
@@ -207,10 +211,10 @@ export function Team() {
   const hasMoreMembers = filteredMembers.length > INITIAL_DISPLAY_COUNT;
   const hiddenCount = filteredMembers.length - INITIAL_DISPLAY_COUNT;
 
-  // Reset expanded state when tab changes
+  // Reset expanded state when tab or search changes
   useEffect(() => {
     setIsExpanded(false);
-  }, [activeTab]);
+  }, [activeTab, searchQuery]);
 
   return (
     <section
@@ -238,26 +242,41 @@ export function Team() {
           </p>
         </motion.div>
 
-        {/* Filter Tabs */}
+        {/* Search + Filter */}
         <motion.div
           variants={fadeInUp}
           initial="hidden"
           animate={isInView ? "visible" : "hidden"}
           transition={{ delay: 0.2 }}
-          className="flex flex-wrap justify-center gap-2 mb-10"
+          className="flex flex-col items-center gap-4 mb-10"
         >
-          {MUNICIPALITIES.map((municipality) => (
-            <button
-              key={municipality}
-              onClick={() => setActiveTab(municipality)}
-              className={cn(
-                "tab",
-                activeTab === municipality && "tab-active"
-              )}
-            >
-              {municipality}
-            </button>
-          ))}
+          {/* Search Bar */}
+          <div className="relative w-full max-w-sm">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+            <input
+              type="text"
+              placeholder="Search by name or role…"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="input pl-10 text-sm"
+            />
+          </div>
+
+          {/* Filter Tabs */}
+          <div className="flex flex-wrap justify-center gap-2">
+            {MUNICIPALITIES.map((municipality) => (
+              <button
+                key={municipality}
+                onClick={() => setActiveTab(municipality)}
+                className={cn(
+                  "tab",
+                  activeTab === municipality && "tab-active"
+                )}
+              >
+                {municipality}
+              </button>
+            ))}
+          </div>
         </motion.div>
 
         {/* Team Grid */}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -23,7 +23,7 @@ export const SITE_CONFIG = {
   heroTitle: "Alternative Learning System",
   heroSubtitle: "BUKIDNON CLUSTER I",
   heroDescription:
-    "Bringing quality and flexible education to learners in Bukidnon.",
+    "Bringing quality and flexible education to out-of-school youth and adults across Manolo Fortich, Libona, Baungon, and Malitbog — empowering learners through the A&E Test pathway and lifelong learning.",
   videoUrl: "https://www.youtube.com/embed/2-ZgNsubzcs",
   videoTitle: "The Untold Story of ALS Teachers",
   videoDescription:


### PR DESCRIPTION
 "feat: remove download restrictions, add stats banner, expand hero, team search

- Remove login/access-code gate from Forms & Documents download buttons
- Add Stats banner component with animated counters (municipalities, educators, programs)
- Insert Stats section between Hero and VideoIntro in page layout
- Expand Hero description to mention all 4 municipalities and A&E Test pathway
- Add name/role search bar to Team section alongside municipality filter tabs"